### PR TITLE
fix(man1/bash.1): the shopt missing option autocd

### DIFF
--- a/src/man1/bash.1
+++ b/src/man1/bash.1
@@ -6236,6 +6236,11 @@ Enable
 .if n .sp 1v
 .PD 0
 .TP 8
+.B autocd
+如果设置的话，当把目录的名字直接作为命令执行时跟把它作为内建命令
+.B cd
+的参数执行时一样，这个选项只能在交互 shell 中使用。
+.TP 8
 .B cdable_vars
 如果设置的话，内建命令
 .B cd


### PR DESCRIPTION
内建命令 shopt 的可用参数少了 autocd